### PR TITLE
Add Dynamic HalfOpenPeriod and WhileHalfOpen ResetMode for Improved Retry Handling

### DIFF
--- a/Rebus.CircuitBreaker.Tests/CircuitBreaker/CircuitBreakerTests.cs
+++ b/Rebus.CircuitBreaker.Tests/CircuitBreaker/CircuitBreakerTests.cs
@@ -1,14 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using Rebus.Activation;
 using Rebus.Bus;
 using Rebus.Config;
 using Rebus.Logging;
-using Rebus.Retry.Simple;
 using Rebus.Transport.InMem;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
 // ReSharper disable ArgumentsStyleAnonymousFunction
 #pragma warning disable 1998
 
@@ -114,6 +114,209 @@ public class CircuitBreakerTests : FixtureBase
         Console.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] Assert state changes -> open -> half open -> open");
         Assert.That(stateChanges, Is.EquivalentTo(new CircuitBreakerState[] { CircuitBreakerState.Open, CircuitBreakerState.HalfOpen, CircuitBreakerState.Open }), $"[{DateTime.Now:HH:mm:ss.fff}] Expect state transitions -> open -> half open -> open after halfOpenPeriod");
     }
+
+    [Test]
+    public async Task WaitDynamicHalfOpenPeriodBeforeHalfOpening()
+    {
+        const int TimingMargin = 2;
+
+        var stateChanges = new List<CircuitBreakerState>();
+        var events = new CircuitBreakerEvents();
+        events.CircuitBreakerChanged += stateChanges.Add;
+
+        var deliveryCount = 0;
+        bool handlerWillThrow = true;
+      
+        var bus = ConfigureBus(
+            handlers: a => a.Handle<string>(async _ =>
+            {
+                deliveryCount++;
+                await Task.Delay(100); // Make handler take reasonable amount of time.
+                if (handlerWillThrow) throw new MyCustomException();
+            }),
+            options: o =>
+            {
+                o.EnableCircuitBreaker(
+                    c => c.OpenOn<MyCustomException>(
+                        attempts: 1, 
+                        trackingPeriodInSeconds: 5,
+                        halfOpenPeriodProvider: attemptCount => TimeSpan.FromSeconds(4 + (attemptCount % 2) * 4), // 5, 10, 5, 10, etc...
+                        resetIntervalInSeconds: 2,
+                        resetMode: ResetMode.WhileHalfOpen));
+                o.Decorate(c => events);
+            },
+            false
+        );
+
+        await bus.SendLocal("Uh oh, This is not gonna go well!");
+
+        // Expect state changes according to sequence of halfOpen periods: 5s, 10s, 5s, 10s, etc...
+
+        Assert.That(
+            () => stateChanges, 
+            Is.EquivalentTo(new CircuitBreakerState[] { CircuitBreakerState.Open }).After(2500).PollEvery(100),
+            "Expect circuit opens after failure");
+        stateChanges.Clear();
+
+        Assert.That(
+            () => stateChanges,
+            Is.EquivalentTo(new CircuitBreakerState[] { CircuitBreakerState.HalfOpen, CircuitBreakerState.Open }).After(4 + TimingMargin).Seconds.PollEvery(100),
+            "Expect circuit half opens then opens again after half open period of 4s");
+        stateChanges.Clear();
+        Stopwatch stopwatch = Stopwatch.StartNew();
+
+        Assert.That(
+            () => stateChanges,
+            Is.EquivalentTo(new CircuitBreakerState[] { CircuitBreakerState.HalfOpen, CircuitBreakerState.Open }).After(8 + TimingMargin).Seconds.PollEvery(100),
+            "Expect circuit half opens then opens again after half open period of 8s");
+        Assert.That(
+            stopwatch.ElapsedMilliseconds,
+            Is.GreaterThan(8000 - TimingMargin * 1000),
+            "Expect half open period to take close to 8 seconds");
+        stateChanges.Clear();
+
+        Assert.That(
+            () => stateChanges,
+            Is.EquivalentTo(new CircuitBreakerState[] { CircuitBreakerState.HalfOpen, CircuitBreakerState.Open }).After(4 + TimingMargin).Seconds.PollEvery(100),
+            "Expect circuit half opens then opens again after half open period of 4s");
+        stateChanges.Clear();
+
+        handlerWillThrow = false;
+        Assert.That(
+            () => stateChanges,
+            Is.EquivalentTo(new CircuitBreakerState[] { CircuitBreakerState.HalfOpen, CircuitBreakerState.Closed }).After(8 + 2 + TimingMargin).Seconds.PollEvery(100),
+            "Expect circuit half opens, message succeeds, and closes again after half open period of 8s + reset interval of 2s");
+        stateChanges.Clear();
+    }
+
+    [Test]
+    public async Task DynamicHalfOpenPeriodResets()
+    {
+        int lastAttemptCount = 0;
+        int deliveryCount = 0;
+        var handlerWillThrow = true;
+        var stateChanges = new List<CircuitBreakerState>();
+
+        var events = new CircuitBreakerEvents();
+        events.CircuitBreakerChanged += (CircuitBreakerState newState) =>
+        {
+            Console.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] Circuit breaker state changed {stateChanges.LastOrDefault()} -> {newState}");
+            stateChanges.Add(newState);
+        };
+
+        var bus = ConfigureBus(
+            handlers: a => a.Handle<string>(async _ =>
+            {
+                deliveryCount++;
+                await Task.Delay(100); // Make handler take reasonable amount of time.
+                if (handlerWillThrow) throw new MyCustomException();
+            }),
+            options: o =>
+            {
+                o.EnableCircuitBreaker(
+                    c => c.OpenOn<MyCustomException>(
+                        attempts: 1,
+                        trackingPeriodInSeconds: 10,
+                        halfOpenPeriodProvider: attemptCount => {
+                            lastAttemptCount = attemptCount;
+                            return TimeSpan.FromSeconds(1);
+                        },
+                        resetIntervalInSeconds: 1,
+                        resetMode: ResetMode.WhileHalfOpen));
+                o.Decorate(c => events);
+            },
+            false
+        );
+
+        handlerWillThrow = true;
+        await bus.SendLocal("Uh oh, This is not gonna go well!");
+        Assert.That(() => lastAttemptCount, Is.EqualTo(2).After(10).Seconds.PollEvery(100));
+        
+        handlerWillThrow = false;
+
+        // Wait for circuit breaker to close
+        stateChanges.Clear();
+        Assert.That(() => stateChanges, Does.Contain(CircuitBreakerState.Closed).After(10).Seconds.PollEvery(100));
+
+        handlerWillThrow = true;
+        await bus.SendLocal("Uh oh, This is not gonna go well!");
+
+        // Expect attempt count to be reset
+        Assert.That(() => lastAttemptCount, Is.EqualTo(1).After(10).Seconds.PollEvery(100));
+    }
+
+    [Test]
+    public async Task ResetModeWhileHalfOpenPreventsClosingWhileOpen()
+    {
+        const int HalfOpenPeriod = 8;
+        const int ResetInterval = 8;
+        const int TimingMargin = 2;
+
+        var stateChanges = new List<CircuitBreakerState>();
+        var events = new CircuitBreakerEvents();
+        events.CircuitBreakerChanged += (CircuitBreakerState newState) =>
+        {
+            Console.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] Circuit breaker state changed {stateChanges.LastOrDefault()} -> {newState}");
+            stateChanges.Add(newState);
+        };
+
+        bool handlerWillThrow = true;
+      
+        var bus = ConfigureBus(
+            handlers: a => a.Handle<string>(async _ =>
+            {
+                await Task.Delay(100); // Make handler take reasonable amount of time.
+                if (handlerWillThrow) throw new MyCustomException();
+            }),
+            options: o =>
+            {
+                o.EnableCircuitBreaker(
+                    c => c.OpenOn<MyCustomException>(
+                        attempts: 1, 
+                        trackingPeriodInSeconds: 10,
+                        halfOpenPeriodInSeconds: HalfOpenPeriod,
+                        resetIntervalInSeconds: ResetInterval,
+                        resetMode: ResetMode.WhileHalfOpen));
+                o.Decorate(c => events);
+            },
+            false
+        );
+
+        await bus.SendLocal("Uh oh, This is not gonna go well!");
+
+        Assert.That(
+            () => stateChanges, 
+            Is.EquivalentTo(new CircuitBreakerState[] { CircuitBreakerState.Open }).After(TimingMargin).Seconds.PollEvery(100),
+            "Expect circuit opens after failure");
+        stateChanges.Clear();
+
+        handlerWillThrow = false;
+
+        Assert.That(
+            () => stateChanges,
+            Is.EquivalentTo(new CircuitBreakerState[] { }).After(HalfOpenPeriod - TimingMargin).Seconds,
+            "Expect circuit remains open for halfOpenPeriod");
+        stateChanges.Clear();
+
+        Assert.That(
+            () => stateChanges,
+            Is.EquivalentTo(new CircuitBreakerState[] { CircuitBreakerState.HalfOpen }).After(TimingMargin*2).Seconds.PollEvery(100),
+            "Expect circuit to transition to halfOpen after halfOpenPeriod");
+        stateChanges.Clear();
+
+        Assert.That(
+            () => stateChanges,
+            Is.EquivalentTo(new CircuitBreakerState[] { }).After(ResetInterval - TimingMargin).Seconds,
+            "Expect circuit remains halfOpen within resetPeriod");
+        stateChanges.Clear();
+
+        Assert.That(
+            () => stateChanges,
+            Is.EquivalentTo(new CircuitBreakerState[] { CircuitBreakerState.Closed }).After(TimingMargin * 2).Seconds.PollEvery(100),
+            "Expect circuit to transition to closed after resetPeriod");
+        stateChanges.Clear();
+    }
+
 
     IBus ConfigureBus(Action<BuiltinHandlerActivator> handlers, Action<OptionsConfigurer> options, bool useBusStarter)
     {

--- a/Rebus.CircuitBreaker/CircuitBreaker/ResetMode.cs
+++ b/Rebus.CircuitBreaker/CircuitBreaker/ResetMode.cs
@@ -1,0 +1,21 @@
+﻿namespace Rebus.CircuitBreaker;
+
+/// <summary>
+/// Describes how the circuit breaker resets to a closed state
+/// </summary>
+public enum ResetMode
+{
+    /// <summary>
+    /// The circuit can reset (close) from any state. 
+    /// The reset interval is measured from the most recent error
+    /// </summary>
+    WhileAnyState,
+
+    /// <summary>
+    /// The circuit can reset (close) only when in the HalfOpen state. 
+    /// The reset interval is measured from the later of:
+    /// - The most recent error.
+    /// - The moment the circuit entered the HalfOpen state.
+    /// </summary>
+    WhileHalfOpen,
+}

--- a/Rebus.CircuitBreaker/Config/CircuitBreakerSettings.cs
+++ b/Rebus.CircuitBreaker/Config/CircuitBreakerSettings.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Rebus.CircuitBreaker;
+using System;
 
 namespace Rebus.Config;
 
@@ -43,18 +44,40 @@ class CircuitBreakerSettings
     internal TimeSpan CloseResetInterval { get; private set; }
 
     /// <summary>
+    /// The <see cref="ResetMode"/> the circuit breaker will operate in
+    /// </summary>
+    internal ResetMode ResetMode { get; private set; }
+
+    /// <summary>
     /// Time Interval for when the circuit breaker will move to Half Open after being in an Open State
     /// </summary>
-    internal TimeSpan HalfOpenResetInterval { get; private set; }
+    internal Func<int, TimeSpan> HalfOpenResetIntervalProvider { get; private set; }
 
     /// <summary>
     /// Create a setting for a given circuit breaker
     /// </summary>
-    internal CircuitBreakerSettings(int attempts, int trackingPeriodInSeconds, int halfOpenResetIntervalInSeconds, int closedResetIntervalInSeconds)
+    internal CircuitBreakerSettings(
+        int attempts,
+        int trackingPeriodInSeconds,
+        int halfOpenResetInterval,
+        int closedResetIntervalInSeconds,
+        ResetMode resetMode = ResetMode.WhileAnyState)
+        : this(attempts, trackingPeriodInSeconds, _ => TimeSpan.FromSeconds(halfOpenResetInterval), closedResetIntervalInSeconds, resetMode)
+    { }
+
+    /// <summary>
+    /// Create a setting for a given circuit breaker
+    /// </summary>
+    internal CircuitBreakerSettings(
+        int attempts, int trackingPeriodInSeconds, 
+        Func<int, TimeSpan> halfOpenResetIntervalProvider, 
+        int closedResetIntervalInSeconds, 
+        ResetMode resetMode = ResetMode.WhileAnyState)
     {
         Attempts = attempts;
         TrackingPeriod = TimeSpan.FromSeconds(trackingPeriodInSeconds);
-        HalfOpenResetInterval = TimeSpan.FromSeconds(halfOpenResetIntervalInSeconds);
+        HalfOpenResetIntervalProvider = halfOpenResetIntervalProvider;
         CloseResetInterval = TimeSpan.FromSeconds(closedResetIntervalInSeconds);
+        ResetMode = resetMode;
     }
 }


### PR DESCRIPTION
# Context
I'm opening this PR to see if you're interested in upstreaming some enhancements from my fork, designed to better handle specific retry scenarios.

I needed to address the following challenges:
- Messages are sent to a DLQ after too many retries (this behavior is outside our control).
- When an upstream service fails for extended periods, we want to prevent excessive retries while still allowing recovery.
- Initial retries shouldn’t be excessively delayed to accommodate transient failures.

To solve this, I've implemented a dynamic HalfOpenPeriod that enables exponential backoff. After an error closes the circuit, it initially enters HalfOpen quickly, but each subsequent attempt takes progressively longer if failures persist. Additionally, I introduced a new ResetMode to complement this behavior.

# Feature Description

## Dynamic HalfOpenPeriod:
HalfOpenPeriod can now vary based on how many consecutive times the circuit enters the HalfOpen state. This enables exponential backoff.

```c#
                o.EnableCircuitBreaker(
                    c => c.OpenOn<MyCustomException>(
                        attempts: 1, 
                        trackingPeriodInSeconds: 60,
                        // halfOpenPeriod = 30s, 90s, 270s, etc...
                        halfOpenPeriodProvider: attemptCount => TimeSpan.FromSeconds(30 * Math.Pow(3, attemptCount)),                      
                        resetIntervalInSeconds: 60,
                        resetMode: ResetMode.WhileHalfOpen));
```

## WhileHalfOpen ResetMode:
Introduces two ResetModes:
- **WhileAnyState (default)**: Matches the current behavior.
- **WhileHalfOpen**: The circuit resets (closes) only while in HalfOpen state, with the reset interval starting when it enters HalfOpen.

### Motivation:

Prevents resets from occurring while the circuit is still open when ResetInterval < HalfOpenPeriod. This is crucial for dynamic HalfOpenPeriods, ensuring that ResetInterval remains meaningful across varying HalfOpenPeriods.

# Summary
I've taken care to implement the changes in a backwards compatible way. Let me know if you'd like to incorporate this into the project, and if any modifications or further explanations are needed.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
